### PR TITLE
GPU Sanitizer support for global variables

### DIFF
--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -619,6 +619,8 @@ struct GPUSanTy {
   void addGPUSanNewFn(GenericKernelTy &GK) { NewFns.push_back(&GK); }
   void addGPUSanFreeFn(GenericKernelTy &GK) { FreeFns.push_back(&GK); }
   void checkAndReportError();
+  Error transferFakePtrToDevice(const char *GlobalName, void *FakeHstPtr,
+                                SmallVector<DeviceImageTy *> &Images);
 
 private:
   uint32_t SlotCnt = SanitizerConfig<AllocationKind::GLOBAL>::SLOTS - 1;
@@ -762,6 +764,13 @@ struct GenericDeviceTy : public DeviceAllocatorTy {
     if (!HstPtr)
       return Error::success();
     return PinnedAllocs.unlockUnmappedHostBuffer(HstPtr);
+  }
+
+  /// Transfers a fake pointer to its respective shadow variable to prevent
+  /// double initializing GPUSan shadow constants. Only runs if GPUSan is
+  /// enabled
+  Error transferFakePtrToDevice(const char *GlobalName, void *FakeHstPtr) {
+    return GPUSan.transferFakePtrToDevice(GlobalName, FakeHstPtr, LoadedImages);
   }
 
   /// Check whether the host buffer with address \p HstPtr is pinned by the

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -2360,12 +2360,12 @@ void GPUSanTy::checkAndReportError() {
   case SanitizerTrapInfoTy::None:
     llvm_unreachable("Unexpected exception");
   case SanitizerTrapInfoTy::ExceedsLength:
-    fprintf(stderr, "%sERROR: OffloadSanitizer %s\n%s", Red(), "exceeds length",
-            Default());
+    fprintf(stderr, "%sERROR: OffloadSanitizer %s %d\n%s", Red(),
+            "exceeds length", STI->PtrSlot, Default());
     break;
   case SanitizerTrapInfoTy::ExceedsSlots:
-    fprintf(stderr, "%sERROR: OffloadSanitizer %s\n%s", Red(), "exceeds slots",
-            Default());
+    fprintf(stderr, "%sERROR: OffloadSanitizer %s %d\n%s", Red(),
+            "exceeds slots", STI->PtrSlot, Default());
     break;
   case SanitizerTrapInfoTy::PointerOutsideAllocation:
     fprintf(stderr, "%sERROR: OffloadSanitizer %s : %p : %i %lu (%s)\n%s",
@@ -2384,14 +2384,35 @@ void GPUSanTy::checkAndReportError() {
     DiagnoseAccess("use-after-free");
     break;
   case SanitizerTrapInfoTy::MemoryLeak:
-    fprintf(stderr, "%sERROR: OffloadSanitizer %s\n%s", Red(), "memory leak",
-            Default());
+    fprintf(stderr, "%sERROR: OffloadSanitizer memory leak at slot %d\n%s",
+            Red(), STI->PtrSlot, Default());
     break;
   case SanitizerTrapInfoTy::GarbagePointer:
     DiagnoseAccess("garbage-pointer");
     break;
   }
   fflush(stderr);
+}
+
+Error GPUSanTy::transferFakePtrToDevice(const char *GlobalName,
+                                        void *FakeHstPtr,
+                                        SmallVector<DeviceImageTy *> &Images) {
+  if (!FakeHstPtr)
+    return Plugin::success();
+
+  std::string ShadowName("__san.global.");
+  ShadowName.append(GlobalName);
+
+  GenericGlobalHandlerTy &GHandler = Device.Plugin.getGlobalHandler();
+  GlobalTy ShadowGlobal(ShadowName, sizeof(void *), &FakeHstPtr);
+
+  int imgCount = 0;
+  for (auto Img : Images) {
+    if (GHandler.isSymbolInImage(Device, *Img, ShadowName))
+      return GHandler.writeGlobalToDevice(Device, *Img, ShadowGlobal);
+  }
+
+  return Plugin::error("Shadow global for '%s' not found", GlobalName);
 }
 
 bool llvm::omp::target::plugin::libomptargetSupportsRPC() {

--- a/offload/src/omptarget.cpp
+++ b/offload/src/omptarget.cpp
@@ -288,6 +288,11 @@ static int initLibrary(DeviceTy &Device) {
                                     CurrHostEntry->size,
                                     Entry->FakeTgtPtrBegin))
           return OFFLOAD_FAIL;
+
+        auto &DeviceInterface = Device.RTL->getDevice(DeviceId);
+        if (DeviceInterface.transferFakePtrToDevice(CurrHostEntry->name,
+                                                    Entry->FakeTgtPtrBegin))
+          return OFFLOAD_FAIL;
       }
     }
   }

--- a/offload/test/sanitizer/global_null.c
+++ b/offload/test/sanitizer/global_null.c
@@ -1,6 +1,6 @@
 // clang-format off
 // RUN: %libomptarget-compileopt-generic -fsanitize=offload
-// RUN: not %libomptarget-run-generic 2>&1 > %t.out
+// RUN: not %libomptarget-run-generic 2> %t.out
 // RUN: %fcheck-generic --check-prefixes=CHECK < %t.out
 // clang-format on
 

--- a/offload/test/sanitizer/global_variable/global_variable_array_iter_fail.c
+++ b/offload/test/sanitizer/global_variable/global_variable_array_iter_fail.c
@@ -1,8 +1,6 @@
-// clang-format off
-// RUN: %libomptarget-compileopt-generic -fsanitize=offload
+// RUN: %libomptarget-compileopt-generic -g -fsanitize=offload
 // RUN: not %libomptarget-run-generic 2> %t.out
 // RUN: %fcheck-generic --check-prefixes=CHECK < %t.out
-// clang-format on
 
 // UNSUPPORTED: aarch64-unknown-linux-gnu
 // UNSUPPORTED: aarch64-unknown-linux-gnu-LTO
@@ -11,13 +9,19 @@
 // UNSUPPORTED: s390x-ibm-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu-LTO
 
-// Align lines.
+#include <omp.h>
+#include <stdio.h>
 
-int main(void) {
+int global_arr[3] = {1, 2, 3};
+#pragma omp declare target(global_arr)
 
-  int X = 0;
-  int *Random = &X;
+int main() {
 #pragma omp target
-  { *Random = 99; }
-  // CHECK: 0x{{[a-f0-9]*}} is located {{[0-9]*}} bytes inside
+  {
+    // CHECK: is located 12 bytes inside of a 12-byte region
+    for (int i = 0; i < 4; i++) {
+      global_arr[i] *= 4;
+    }
+  }
+  return 0;
 }

--- a/offload/test/sanitizer/global_variable/global_variable_array_pass.c
+++ b/offload/test/sanitizer/global_variable/global_variable_array_pass.c
@@ -1,0 +1,26 @@
+// RUN: %libomptarget-compileopt-generic -g -fsanitize=offload
+// RUN: %libomptarget-run-generic
+
+// UNSUPPORTED: aarch64-unknown-linux-gnu
+// UNSUPPORTED: aarch64-unknown-linux-gnu-LTO
+// UNSUPPORTED: x86_64-pc-linux-gnu
+// UNSUPPORTED: x86_64-pc-linux-gnu-LTO
+// UNSUPPORTED: s390x-ibm-linux-gnu
+// UNSUPPORTED: s390x-ibm-linux-gnu-LTO
+
+#include <omp.h>
+#include <stdio.h>
+
+int global_arr[3] = {1, 2, 3};
+#pragma omp declare target(global_arr)
+
+int main() {
+#pragma omp target
+  {
+    for (int i = 0; i < 3; i++) {
+      global_arr[i] *= 4;
+    }
+    global_arr[1] = 22;
+  }
+  return 0;
+}

--- a/offload/test/sanitizer/global_variable/global_variable_array_static_fail.c
+++ b/offload/test/sanitizer/global_variable/global_variable_array_static_fail.c
@@ -1,8 +1,6 @@
-// clang-format off
-// RUN: %libomptarget-compileopt-generic -fsanitize=offload
+// RUN: %libomptarget-compileopt-generic -g -fsanitize=offload
 // RUN: not %libomptarget-run-generic 2> %t.out
 // RUN: %fcheck-generic --check-prefixes=CHECK < %t.out
-// clang-format on
 
 // UNSUPPORTED: aarch64-unknown-linux-gnu
 // UNSUPPORTED: aarch64-unknown-linux-gnu-LTO
@@ -11,13 +9,17 @@
 // UNSUPPORTED: s390x-ibm-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu-LTO
 
-// Align lines.
+#include <omp.h>
+#include <stdio.h>
 
-int main(void) {
+int global_arr[3] = {1, 2, 3};
+#pragma omp declare target(global_arr)
 
-  int X = 0;
-  int *Random = &X;
+int main() {
 #pragma omp target
-  { *Random = 99; }
-  // CHECK: 0x{{[a-f0-9]*}} is located {{[0-9]*}} bytes inside
+  {
+    // CHECK: is located 20 bytes inside of a 12-byte region
+    global_arr[5] = 27;
+  }
+  return 0;
 }

--- a/offload/test/sanitizer/global_variable/global_variable_pass.c
+++ b/offload/test/sanitizer/global_variable/global_variable_pass.c
@@ -1,0 +1,25 @@
+// RUN: %libomptarget-compileopt-generic -g -fsanitize=offload
+// RUN: %libomptarget-run-generic
+
+// UNSUPPORTED: aarch64-unknown-linux-gnu
+// UNSUPPORTED: aarch64-unknown-linux-gnu-LTO
+// UNSUPPORTED: x86_64-pc-linux-gnu
+// UNSUPPORTED: x86_64-pc-linux-gnu-LTO
+// UNSUPPORTED: s390x-ibm-linux-gnu
+// UNSUPPORTED: s390x-ibm-linux-gnu-LTO
+
+#include <omp.h>
+#include <stdio.h>
+
+int global1 = 0;
+int global2 = -1;
+#pragma omp declare target(global1, global2)
+
+int main() {
+#pragma omp target
+  {
+    global1 = 72;
+    global2 = global1 + 75;
+  }
+  return 0;
+}

--- a/offload/test/sanitizer/heap_null.c
+++ b/offload/test/sanitizer/heap_null.c
@@ -1,6 +1,6 @@
 // clang-format off
 // RUN: %libomptarget-compileopt-generic -fsanitize=offload
-// RUN: not %libomptarget-run-generic 2>&1 > %t.out
+// RUN: not %libomptarget-run-generic 2> %t.out
 // RUN: %fcheck-generic --check-prefixes=CHECK < %t.out
 // clang-format on
 


### PR DESCRIPTION
This pull request extends GPU sanitizer support to global variables. Shadow variables that store the fake pointer values are added for each user-defined global. Right now, globals are registered by the host and de-allocated by the device, but this is expected to change in the future. The device-side allocation function is in the instrumentation pass, but it's commented out for now. Global variable references are rewritten as load instructions that get their respective fake pointer from the shadow globals.