### PR TITLE
[Instrumentor] Add target configuration options

### DIFF
--- a/llvm/include/llvm/Transforms/Instrumentation/InstrumentorConfig.def
+++ b/llvm/include/llvm/Transforms/Instrumentation/InstrumentorConfig.def
@@ -23,11 +23,16 @@ CVALUE(Base, bool, PrintRuntimeSignatures, true)
 
 CVALUE(Base, std::string, StubRuntimePath, "rt.c")
 
-CVALUE(Base, std::string, TargetRegex, ".*")
+/// Regex string that is matched against the current target.
+/// This target option has the highest precedence. If the target
+/// string doesn't match the regex, it won't be instrumented.
+CVALUE(Base, std::string, EnabledTargetRegex, ".*")
 
-CVALUE(Base, bool, InstrumentHost, true)
+/// Instrument non-GPU targets
+CVALUE(Base, bool, EnabledTargetHost, true)
 
-CVALUE(Base, bool, InstrumentGpu, true)
+/// Instrument GPU targets (AMDGPU and NVPTX)
+CVALUE(Base, bool, EnabledTargetGPU, true)
 
 SECTION_END(Base)
 ///}

--- a/llvm/include/llvm/Transforms/Instrumentation/InstrumentorConfig.def
+++ b/llvm/include/llvm/Transforms/Instrumentation/InstrumentorConfig.def
@@ -23,6 +23,12 @@ CVALUE(Base, bool, PrintRuntimeSignatures, true)
 
 CVALUE(Base, std::string, StubRuntimePath, "rt.c")
 
+CVALUE(Base, std::string, TargetRegex, ".*")
+
+CVALUE(Base, bool, InstrumentHost, true)
+
+CVALUE(Base, bool, InstrumentGpu, true)
+
 SECTION_END(Base)
 ///}
 

--- a/llvm/lib/Transforms/Instrumentation/Instrumentor.cpp
+++ b/llvm/lib/Transforms/Instrumentation/Instrumentor.cpp
@@ -942,7 +942,6 @@ bool InstrumentorImpl::instrumentCall(CallBase &I,
     break;
   case Intrinsic::not_intrinsic:
     Changed |= instrumentGenericCall(I, P);
-    break;
   default:
     break;
   }
@@ -1713,15 +1712,16 @@ bool InstrumentorImpl::canInstrumentTarget() {
   const auto TripleStr = M.getTargetTriple();
   const auto &T = Triple(TripleStr);
   const bool IsGPU = T.isAMDGPU() || T.isNVPTX();
-  llvm::Regex TargetRegex(IC.Base.TargetRegex);
+  llvm::Regex TargetRegex(IC.Base.EnabledTargetRegex);
   std::string ErrMsg;
 
   if (!TargetRegex.isValid(ErrMsg)) {
     errs() << "WARNING: failed to parse TargetRegex: " << ErrMsg << "\n";
+    return false;
   }
 
-  return ((IsGPU && IC.Base.InstrumentGpu) ||
-          (!IsGPU && IC.Base.InstrumentHost)) &&
+  return ((IsGPU && IC.Base.EnabledTargetGPU) ||
+          (!IsGPU && IC.Base.EnabledTargetHost)) &&
          TargetRegex.match(TripleStr);
 }
 

--- a/llvm/test/Instrumentation/Instrumentor/default_config.json
+++ b/llvm/test/Instrumentation/Instrumentor/default_config.json
@@ -3,9 +3,9 @@
     "RuntimeName": "__instrumentor_",
     "PrintRuntimeSignatures": true,
     "StubRuntimePath": "rt.c",
-    "TargetRegex": ".*",
-    "InstrumentHost": true,
-    "InstrumentGpu": true
+    "EnabledTargetRegex": ".*",
+    "EnabledTargetHost": true,
+    "EnabledTargetGPU": true
   },
   "alloca": {
     "EnabledPost": true,

--- a/llvm/test/Instrumentation/Instrumentor/default_config.json
+++ b/llvm/test/Instrumentation/Instrumentor/default_config.json
@@ -2,7 +2,10 @@
   "Base": {
     "RuntimeName": "__instrumentor_",
     "PrintRuntimeSignatures": true,
-    "StubRuntimePath": "rt.c"
+    "StubRuntimePath": "rt.c",
+    "TargetRegex": ".*",
+    "InstrumentHost": true,
+    "InstrumentGpu": true
   },
   "alloca": {
     "EnabledPost": true,


### PR DESCRIPTION
This PR adds three new options to the base configuration: `InstrumentHost`, `InstrumentGpu`, and `TargetRegex`. The instrumentor will only run on targets that can be matched against the provided `TargetRegex`. Non-GPU targets will be modified if `InstrumentHost` is true, and GPU targets will be instrumented if `InstrumentGpu` is true.