### PR TITLE
[Instrumentor] Add target configuration options

### DIFF
--- a/llvm/include/llvm/Transforms/Instrumentation/Instrumentor.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/Instrumentor.h
@@ -405,6 +405,15 @@ struct InstrumentationConfig {
     DemangleFunctionNames = BaseConfigurationOpportunity::getBoolOption(
         *this, "demangle_function_names",
         "Demangle functions names passed to the runtime.", true);
+    TargetRegex = BaseConfigurationOpportunity::getStringOption(
+        *this, "target_regex",
+        "Regular expression to be matched against the module target. "
+        "Only targets that match this regex will be instrumented",
+        "");
+    HostEnabled = BaseConfigurationOpportunity::getBoolOption(
+        *this, "host_enabled", "Instrument non-GPU targets", true);
+    GPUEnabled = BaseConfigurationOpportunity::getBoolOption(
+        *this, "gpu_enabled", "Instrument GPU targets", true);
   }
 
   bool ReadConfig = true;
@@ -425,6 +434,9 @@ struct InstrumentationConfig {
   BaseConfigurationOpportunity *RuntimePrefix;
   BaseConfigurationOpportunity *RuntimeStubsFile;
   BaseConfigurationOpportunity *DemangleFunctionNames;
+  BaseConfigurationOpportunity *TargetRegex;
+  BaseConfigurationOpportunity *HostEnabled;
+  BaseConfigurationOpportunity *GPUEnabled;
 
   EnumeratedArray<StringMap<InstrumentationOpportunity *>,
                   InstrumentationLocation::KindTy>

--- a/llvm/test/Instrumentation/Instrumentor/default_config.json
+++ b/llvm/test/Instrumentation/Instrumentor/default_config.json
@@ -5,7 +5,13 @@
     "runtime_stubs_file": "test.c",
     "runtime_stubs_file.description": "The file into which runtime stubs should be written.",
     "demangle_function_names": true,
-    "demangle_function_names.description": "Demangle functions names passed to the runtime."
+    "demangle_function_names.description": "Demangle functions names passed to the runtime.",
+    "target_regex": "",
+    "target_regex.description": "Regular expression to be matched against the module target. Only targets that match this regex will be instrumented",
+    "host_enabled": true,
+    "host_enabled.description": "Instrument non-GPU targets",
+    "gpu_enabled": true,
+    "gpu_enabled.description": "Instrument GPU targets"
   },
   "module_pre": {
     "module": {


### PR DESCRIPTION
Rewrite of #15. This PR adds three new options to the base configuration: `host_enabled`, `gpu_enabled`, and `target_regex`. The instrumentor will only run on targets that can be matched against the provided target regex. Non-GPU targets will be modified if `target_regex` is true, and GPU targets will be instrumented if `gpu_enabled` is true.
